### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Welcome! The goal of this tutorial is to introduce attendees to the following pa
 These tutorials are made with [Jupyter](https://jupyter.org), which is a
 browser based interactive Python notebook.
 
+The tutorial is available here: https://pv-tutorials.github.io/2024_Modeling_Webinar
+
 ### Jupyter Books
 
 The tutorial content is also hosted as a [Jupyter book](https://jupyterbook.org/intro.html):

--- a/README.md
+++ b/README.md
@@ -9,13 +9,6 @@ browser based interactive Python notebook.
 
 The tutorial is available here: https://pv-tutorials.github.io/2024_Modeling_Webinar
 
-### Jupyter Books
-
-The tutorial content is also hosted as a [Jupyter book](https://jupyterbook.org/intro.html):
-
-[![Jupyter Book Badge](https://jupyterbook.org/badge.svg)](<https://pv-tutorials.github.io/2024_Modeling_Webinar/>)
-
-
 ### Running Locally
 
 You can run the tutorial locally with


### PR DESCRIPTION
There seems to be missing a link to the tutorials in the README.

Same for https://github.com/PV-Tutorials/2024_Analytics_Webinar